### PR TITLE
add time remaining flow

### DIFF
--- a/skills/declarative/calendarskill/calendarskill.dialog
+++ b/skills/declarative/calendarskill/calendarskill.dialog
@@ -288,6 +288,23 @@
           ]
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "7vdrMD"
+      },
+      "intent": "TimeRemaining",
+      "actions": [
+        {
+          "$kind": "Microsoft.BeginDialog",
+          "$designer": {
+            "id": "wvnDDL"
+          },
+          "activityProcessed": true,
+          "dialog": "TimeRemainingDialog"
+        }
+      ]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",

--- a/skills/declarative/calendarskill/dialogs/SearchMeetings/SearchMeetings.dialog
+++ b/skills/declarative/calendarskill/dialogs/SearchMeetings/SearchMeetings.dialog
@@ -26,7 +26,7 @@
             },
             {
               "property": "dialog.slots.Subject",
-              "value": "=coalesce(@Subject, $Subject)"
+              "value": "=coalesce(@Subject, @SubjectPattenAny, $Subject)"
             },
             {
               "property": "dialog.slots.FromDate",
@@ -51,7 +51,7 @@
           "$designer": {
             "id": "cTHmKE"
           },
-          "condition": "dialog.slots.FromTime == null && dialog.slots.FromDate == null &&  dialog.slots.title == null",
+          "condition": "dialog.slots.FromTime == null && dialog.slots.FromDate == null &&  dialog.slots.Subject == null",
           "actions": [
             {
               "$kind": "Microsoft.TextInput",
@@ -144,7 +144,8 @@
             "startDateTime": "=dialog.startDateTime",
             "query": "=dialog.title"
           },
-          "resultProperty": "dialog.requestResult"
+          "resultProperty": "dialog.requestResult",
+          "activityProcessed": true
         },
         {
           "$kind": "Microsoft.IfCondition",

--- a/skills/declarative/calendarskill/dialogs/TimeRemainingDialog/TimeRemainingDialog.dialog
+++ b/skills/declarative/calendarskill/dialogs/TimeRemainingDialog/TimeRemainingDialog.dialog
@@ -1,0 +1,148 @@
+{
+  "$kind": "Microsoft.AdaptiveDialog",
+  "$designer": {
+    "id": "cU20nz",
+    "name": "TimeRemainingDialog"
+  },
+  "autoEndDialog": true,
+  "defaultResultProperty": "dialog.result",
+  "triggers": [
+    {
+      "$kind": "Microsoft.OnBeginDialog",
+      "$designer": {
+        "name": "BeginDialog",
+        "id": "0wgdKE"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SetProperties",
+          "$designer": {
+            "id": "IszNNb"
+          },
+          "assignments": [
+            {
+              "value": "=coalesce(@Subject, @SubjectPattenAny, $Subject)",
+              "property": "dialog.slots.subject"
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.SetProperties",
+          "$designer": {
+            "id": "V6GKZs"
+          },
+          "assignments": [
+            {
+              "property": "dialog.startDateTime",
+              "value": "= utcNow()"
+            },
+            {
+              "property": "dialog.endDateTime",
+              "value": "= addHours(formatDateTime(dialog.startDateTime), 24 * 7)"
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "nlmCSf"
+          },
+          "actions": [
+            {
+              "$kind": "Microsoft.BeginDialog",
+              "$designer": {
+                "id": "Jk9ftA"
+              },
+              "activityProcessed": true,
+              "dialog": "GetMeetingRequest",
+              "options": {
+                "StartDateTime": "=dialog.startDateTime",
+                "EndDateTime": "=dialog.endDateTime"
+              },
+              "resultProperty": "dialog.requestResult"
+            },
+            {
+              "$kind": "Microsoft.TraceActivity",
+              "$designer": {
+                "id": "VGZtsq"
+              }
+            },
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "hbXhbZ"
+              },
+              "condition": "dialog.requestResult != null && count(dialog.requestResult.meetingsList)>0",
+              "actions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "8brEsJ"
+                  },
+                  "activity": "${SendActivity_8brEsJ()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "hIFMwq"
+                  },
+                  "activity": "${SendActivity_hIFMwq()}"
+                }
+              ]
+            }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.BeginDialog",
+              "$designer": {
+                "id": "0bYXR0"
+              },
+              "activityProcessed": true,
+              "dialog": "SearchMeetings",
+              "resultProperty": "dialog.requestResult",
+              "options": {
+                "Subject": "=dialog.slot.subject"
+              }
+            },
+            {
+              "$kind": "Microsoft.TraceActivity",
+              "$designer": {
+                "id": "oCZxt4"
+              },
+              "name": "SearchMeeting"
+            },
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "syQDmU"
+              },
+              "condition": "dialog.requestResult != null",
+              "actions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "oWSUis"
+                  },
+                  "activity": "${SendActivity_oWSUis()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "gWQSo6"
+                  },
+                  "activity": "${SendActivity_gWQSo6()}"
+                }
+              ]
+            }
+          ],
+          "condition": "dialog.slots.subject == null"
+        }
+      ]
+    }
+  ],
+  "generator": "TimeRemainingDialog.lg"
+}

--- a/skills/declarative/calendarskill/dialogs/TimeRemainingDialog/language-generation/en-us/TimeRemainingDialog.en-us.lg
+++ b/skills/declarative/calendarskill/dialogs/TimeRemainingDialog/language-generation/en-us/TimeRemainingDialog.en-us.lg
@@ -1,0 +1,39 @@
+[import](common.lg)
+# FormatMeetingTimeRemainingDuration(startTime, endTime, title)
+- You have ${FormatDurationDisplay((ticks(formatDateTime(endTime)) - ticks(formatDateTime(startTime))) / 10000000)} until your ${title} meeting.
+
+# FormatNextMeetingTimeRemainingDuration(startTime, endTime)
+- You have ${FormatDurationDisplay((ticks(formatDateTime(endTime)) - ticks(formatDateTime(startTime))) / 10000000)} until your next event.
+
+# FormatDurationDisplay(seconds)
+- IF: ${seconds <= 0}
+	- Unexpected duration!
+- ELSEIF: ${seconds < 3600}
+	- ${concat(string(seconds / 60),FormatMinutes(seconds / 60))}
+- ELSEIF: ${seconds % 3600 / 60 != 0}
+	- ${concat(string(seconds / 3600), FormatHours(seconds / 3600), string(seconds % 3600 / 60), FormatMinutes(seconds % 3600 / 60))}
+- ELSE:
+	- ${concat(string(seconds / 3600),FormatHours(seconds / 3600))}
+
+# FormatMinutes(minutes)
+- ${if(minutes > 1,' minutes ',' minute ')}
+
+# FormatHours(hours)
+- ${if(hours > 1,' hours ',' hour ')}
+
+
+
+# SendActivity_8brEsJ()
+- ${FormatNextMeetingTimeRemainingDuration(utcNow(), dialog.requestResult.meetingsList[0].StartTime)}
+
+
+
+# SendActivity_hIFMwq()
+- You don't have any upcomming meeting.
+# SendActivity_oWSUis()
+- ${FormatMeetingTimeRemainingDuration(utcNow(), dialog.requestResult.StartTime, dialog.slots.subject)}
+
+
+
+# SendActivity_gWQSo6()
+- Target meeting not found!

--- a/skills/declarative/calendarskill/language-understanding/en-us/calendarskill.en-us.lu
+++ b/skills/declarative/calendarskill/language-understanding/en-us/calendarskill.en-us.lu
@@ -991,3 +991,60 @@
 
 @ prebuilt ordinal
 @ prebuilt number
+
+# TimeRemaining
+- can you show me the time remaining before my {OrderReference=next} appointment
+- check on the time to see when i {Subject=go to school and pick up mark}
+- do i have any spare time before {OrderReference=next} appointment
+- how long is it until the {FromDate=14th of march}
+- how long till {Subject=disneyland paris}
+- how long till my {OrderReference=next} appointment
+- how long till the {OrderReference=next} meeting
+- how long until {Subject=christmas}
+- how long until my {OrderReference=next} appointment
+- how long until my {OrderReference=next} meeting
+- how long until the {Subject=social}
+- how long will i wait for the {OrderReference=next} appointment
+- how many days is it until {FromDate=christmas}
+- how many days left until the {Subject=opening ceremony}
+- how many days till {FromDate=april}
+- how many days till {FromDate=christmas}
+- how many days until {FromDate=june the fifteenth}
+- how many days until {FromDate=june the fifteenth 2019}
+- how many days until {FromDate=march twenty six}
+- how many days until my {Subject=doctor ' s appointment}
+- how many days until {FromDate=thanksgiving}
+- how many days until the {FromDate=10th of december}
+- how many hours left till the {Subject=closing ceremony}
+- how many hours remaining till {OrderReference=next} appointment
+- how many hours until my {Subject=doc appointment}
+- how many minutes before my {OrderReference=next} appointment
+- how many minutes free do i have before {OrderReference=next} scheduled appointment
+- how much longer do i have before {Subject=pick up mary from school}
+- how much longer do i have until {Subject=pick up john from school}
+- how much longer until my {OrderReference=next} appointment
+- how much longer until my {OrderReference=next} meeting
+- how much time before {Subject=lunch}
+- how much time before my {OrderReference=next} appointment
+- how much time before {OrderReference=next} appointment
+- how much time do i have
+- how much time do i have before my {OrderReference=next} appointment
+- how much time do i have before my {OrderReference=next} meeting
+- how much time do i have free until my {OrderReference=next} meeting
+- how much time do i have until i have to {Subject=meet} with michael
+- how much time do i have until i {Subject=start the meeting}
+- how much time do i have until my {Subject=doc appt}
+- how much time do i have until my meeting with larry
+- how much time do i have until my {OrderReference=next} appointment
+- how much time is there before {Subject=office meeting}
+- how much time remaining till {OrderReference=next} meeting
+- how much time until my meeting with lori
+- how much time until {OrderReference=next} scheduled appointment
+- how much time until {FromTime=noon}
+- i want to know the time left for my {OrderReference=next} appointment
+- show time before {OrderReference=next} appointment
+- tell me how much free time i have before {OrderReference=next} appt
+- tell me how much time before my {OrderReference=next} meeting
+- time before my {OrderReference=next} appointment
+- time remaining
+- ^how long do i have (until|before|till) the [next] (meeting|appointment|{SubjectPattenAny})

--- a/skills/declarative/calendarskill/settings/appsettings.json
+++ b/skills/declarative/calendarskill/settings/appsettings.json
@@ -21,5 +21,10 @@
   "downsampling": {
     "maxImbalanceRatio": 10,
     "maxUtteranceAllowed": 15000
+  },
+  "runtime": {
+    "customRuntime": false,
+    "path": "",
+    "command": ""
   }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Add time remaining flow in calendar skill

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
add time remaining luis and related flow.
![image](https://user-images.githubusercontent.com/16643193/80570482-6cb23080-8a2d-11ea-88e2-e3a06ad676f2.png)

![image](https://user-images.githubusercontent.com/16643193/80573662-f0225080-8a32-11ea-93c8-35ec800dfa48.png)



### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
