### PR TITLE
Implement Implicit User Logout on Unauthorized error

### DIFF
--- a/skills/csharp/experimental/itsmskill/Dialogs/CloseTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/CloseTicketDialog.cs
@@ -65,7 +65,8 @@ namespace ITSMSkill.Dialogs
 
             if (!result.Success)
             {
-                return await SendServiceErrorAndCancelAsync(sc, result, cancellationToken);
+                // Check if Error is UnAuthorized and logout user
+                return await HandleAPIUnauthorizedError(sc, result, cancellationToken);
             }
 
             var card = GetTicketCard(sc.Context, state, result.Tickets[0]);

--- a/skills/csharp/experimental/itsmskill/Dialogs/CreateTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/CreateTicketDialog.cs
@@ -93,7 +93,8 @@ namespace ITSMSkill.Dialogs
 
             if (!result.Success)
             {
-                return await SendServiceErrorAndCancelAsync(sc, result, cancellationToken);
+                // Check if Error is UnAuthorized and logout user
+                return await HandleAPIUnauthorizedError(sc, result, cancellationToken);
             }
 
             var card = GetTicketCard(sc.Context, state, result.Tickets[0]);

--- a/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
@@ -910,6 +910,36 @@ namespace ITSMSkill.Dialogs
             }
         }
 
+        protected async Task<DialogTurnResult> HandleAPIUnauthorizedError(WaterfallStepContext sc, TicketsResult ticketsResult, CancellationToken cancellationToken)
+        {
+            // Check if the error is UnAuthorized
+            if (ticketsResult.Reason.Equals("Unauthorized"))
+            {
+                // Logout User
+                var botAdapter = (BotFrameworkAdapter)sc.Context.Adapter;
+                await botAdapter.SignOutUserAsync(sc.Context, Settings.OAuthConnections.FirstOrDefault().Name, null, cancellationToken);
+
+                // Send Signout Message
+                return await SignOutUser(sc);
+            }
+            else
+            {
+                return await SendServiceErrorAndCancel(sc, ticketsResult);
+            }
+        }
+
+        protected async Task<DialogTurnResult> SendServiceErrorAndCancel(WaterfallStepContext sc, ResultBase result, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await sc.Context.SendActivityAsync(TemplateManager.GenerateActivity(SharedResponses.ServiceFailed), cancellationToken);
+            return await sc.CancelAllDialogsAsync();
+        }
+
+        protected async Task<DialogTurnResult> SignOutUser(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await sc.Context.SendActivityAsync(TemplateManager.GenerateActivity(SharedResponses.SignOut), cancellationToken);
+            return await sc.EndDialogAsync();
+        }
+
         protected async Task<DialogTurnResult> IfKnowledgeHelpAsync(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var intent = (GeneralLuis.Intent)sc.Result;

--- a/skills/csharp/experimental/itsmskill/Dialogs/UpdateTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/UpdateTicketDialog.cs
@@ -128,7 +128,8 @@ namespace ITSMSkill.Dialogs
 
             if (!result.Success)
             {
-                return await SendServiceErrorAndCancelAsync(sc, result, cancellationToken);
+                // Check if Error is UnAuthorized and logout user
+                return await HandleAPIUnauthorizedError(sc, result, cancellationToken);
             }
 
             var card = GetTicketCard(sc.Context, state, result.Tickets[0]);

--- a/skills/csharp/experimental/itsmskill/Models/TicketsResult.cs
+++ b/skills/csharp/experimental/itsmskill/Models/TicketsResult.cs
@@ -11,5 +11,7 @@ namespace ITSMSkill.Models
     public class TicketsResult : ResultBase
     {
         public Ticket[] Tickets { get; set; }
+
+        public string Reason { get; set; }
     }
 }

--- a/skills/csharp/experimental/itsmskill/Responses/Shared/SharedResponses.cs
+++ b/skills/csharp/experimental/itsmskill/Responses/Shared/SharedResponses.cs
@@ -35,5 +35,6 @@ namespace ITSMSkill.Responses.Shared
         public const string ResultIndicator = "ResultIndicator";
         public const string ResultsIndicator = "ResultsIndicator";
         public const string ServiceFailed = "ServiceFailed";
+        public const string SignOut = "SignOut";
     }
 }

--- a/skills/csharp/experimental/itsmskill/Services/ServiceNow/ServiceNowHelper.cs
+++ b/skills/csharp/experimental/itsmskill/Services/ServiceNow/ServiceNowHelper.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Newtonsoft.Json;
+using RestSharp;
+using ITSMSkill.Models;
+using ITSMSkill.Models.ServiceNow;
+
+namespace ITSMSkill.Services.ServiceNow
+{
+    public static class ServiceNowHelper
+    {
+        public static readonly Dictionary<UrgencyLevel, string> UrgencyToString = new Dictionary<UrgencyLevel, string>()
+        {
+            { UrgencyLevel.None, string.Empty},
+            { UrgencyLevel.Low, "3" },
+            { UrgencyLevel.Medium, "2" },
+            { UrgencyLevel.High, "1" }
+        };
+
+        public static readonly Dictionary<string, UrgencyLevel> StringToUrgency = new Dictionary<string, UrgencyLevel>(UrgencyToString.Select(pair => KeyValuePair.Create(pair.Value, pair.Key)));
+        public static readonly Dictionary<TicketState, string> TicketStateToString = new Dictionary<TicketState, string>()
+        {
+            { TicketState.None, string.Empty},
+            { TicketState.New, "1" },
+            { TicketState.InProgress, "2" },
+            { TicketState.OnHold, "3" },
+            { TicketState.Resolved, "6" },
+            { TicketState.Closed, "7" },
+            { TicketState.Canceled, "8" }
+        };
+
+        public static readonly Dictionary<string, TicketState> StringToTicketState = new Dictionary<string, TicketState>(TicketStateToString.Select(pair => KeyValuePair.Create(pair.Value, pair.Key)));
+        public static readonly string Provider = "ServiceNow";
+
+        public static TicketsResult ProcessCreateUpdateCloseTicketIRestResponse(this IRestResponse response)
+        {
+            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
+            {
+                var result = JsonConvert.DeserializeObject<SingleTicketResponse>(response.Content);
+                return new TicketsResult()
+                {
+                    Success = true,
+                    Tickets = new Ticket[] { ConvertTicket(result.result) }
+                };
+            }
+            else if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                return new TicketsResult
+                {
+                    Success = false,
+                    Reason = "Unauthorized"
+                };
+            }
+            else
+            {
+                return new TicketsResult()
+                {
+                    Success = false,
+                    Reason = "Unknown"
+                };
+            }
+        }
+
+        public static TicketsResult ProcessCountTicketIRestResponse(this IRestResponse response)
+        {
+            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
+            {
+                var result = JsonConvert.DeserializeObject<SingleAggregateResponse>(response.Content);
+                return new TicketsResult()
+                {
+                    Success = true,
+                    Tickets = new Ticket[result.result.stats.count]
+                };
+            }
+            else if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                return new TicketsResult
+                {
+                    Success = false,
+                    Reason = "Unauthorized"
+                };
+            }
+            else
+            {
+                return new TicketsResult()
+                {
+                    Success = false,
+                    Reason = "Unknown"
+                };
+            }
+        }
+
+        public static Ticket ConvertTicket(TicketResponse ticketResponse)
+        {
+            var ticket = new Ticket()
+            {
+                Id = ticketResponse.sys_id,
+                Title = ticketResponse.short_description,
+                Description = ticketResponse.description,
+                Urgency = StringToUrgency[ticketResponse.urgency],
+                State = StringToTicketState[ticketResponse.state],
+                OpenedTime = DateTime.Parse(ticketResponse.opened_at),
+                Number = ticketResponse.number,
+                Provider = Provider,
+            };
+
+            if (!string.IsNullOrEmpty(ticketResponse.close_code))
+            {
+                if (!string.IsNullOrEmpty(ticketResponse.close_notes))
+                {
+                    ticket.ResolvedReason = $"{ticketResponse.close_code}:\r\n{ticketResponse.close_notes}";
+                }
+                else
+                {
+                    ticket.ResolvedReason = ticketResponse.close_code;
+                }
+            }
+            else
+            {
+                ticket.ResolvedReason = ticketResponse.close_notes;
+            }
+
+            return ticket;
+        }
+    }
+}

--- a/skills/csharp/tests/itsmskill.tests/API/Fakes/MockServiceNowRestClient.cs
+++ b/skills/csharp/tests/itsmskill.tests/API/Fakes/MockServiceNowRestClient.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ITSMSkill.Models.ServiceNow;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace ITSMSkill.Tests.API.Fakes
@@ -158,12 +160,13 @@ namespace ITSMSkill.Tests.API.Fakes
                .ReturnsAsync(CreateGetUserIdResponseAndCount());
 
             mockClient
-               .Setup(c => c.ExecuteGetTaskAsync<SingleAggregateResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/stats/incident") && r.Parameters.Any(p => p.Name == "sysparm_count" && p.Value is bool && (bool)p.Value))))
-               .ReturnsAsync(CreateIRestResponse(CountTicketResponse));
+                .Setup(c => c.ExecuteTaskAsync(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/stats/incident") && r.Parameters.Any(p => p.Name == "sysparm_count" && p.Value is bool && (bool)p.Value)), It.IsIn(CancellationToken.None), It.IsIn(Method.GET)))
+                .ReturnsAsync(new RestResponse { StatusCode = System.Net.HttpStatusCode.OK, Content = JsonConvert.SerializeObject(CountTicketResponse) });
 
             mockClient
-               .Setup(c => c.ExecutePostTaskAsync<SingleTicketResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/table/incident"))))
-               .ReturnsAsync(CreateIRestResponse(CreateTicketResponse));
+                    .Setup(c => c.ExecuteTaskAsync(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/table/incident")), It.IsIn(CancellationToken.None), It.IsIn(Method.POST)))
+                    .ReturnsAsync(new RestResponse { StatusCode = System.Net.HttpStatusCode.Created, Content = JsonConvert.SerializeObject(CreateTicketResponse) });
+
 
             mockClient
                .Setup(c => c.ExecuteGetTaskAsync<MultiTicketsResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/table/incident"))))
@@ -180,12 +183,13 @@ namespace ITSMSkill.Tests.API.Fakes
 
             // TODO use id is not an ideal way to distinguish
             mockClient
-               .Setup(c => c.ExecuteTaskAsync<SingleTicketResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith($"now/v1/table/incident/{MockData.CreateTicketId}")), It.IsIn(Method.PATCH)))
-               .ReturnsAsync(CreateIRestResponse(CreateTicketResponse));
+                     .Setup(c => c.ExecuteTaskAsync(It.Is<IRestRequest>(r => r.Resource.StartsWith($"now/v1/table/incident/{MockData.CreateTicketId}")), It.IsIn(CancellationToken.None), It.IsIn(Method.PATCH)))
+                     .ReturnsAsync(new RestResponse { StatusCode = System.Net.HttpStatusCode.OK, Content = JsonConvert.SerializeObject(CreateTicketResponse) });
 
             mockClient
-               .Setup(c => c.ExecuteTaskAsync<SingleTicketResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith($"now/v1/table/incident/{MockData.CloseTicketId}")), It.IsIn(Method.PATCH)))
-               .ReturnsAsync(CreateIRestResponse(CloseTicketResponse));
+               .Setup(c => c.ExecuteTaskAsync(It.Is<IRestRequest>(r => r.Resource.StartsWith($"now/v1/table/incident/{MockData.CloseTicketId}")), It.IsIn(CancellationToken.None), It.IsIn(Method.PATCH)))
+               .ReturnsAsync(new RestResponse { StatusCode = System.Net.HttpStatusCode.OK, Content = JsonConvert.SerializeObject(CloseTicketResponse) });
+
 
             mockClient
                .Setup(c => c.ExecuteGetTaskAsync<MultiKnowledgesResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/table/kb_knowledge"))))


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
The change enables logging out user when ServiceNow throws 401, this enables to get user out of the loop by implicitly logging him out.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes it is covered

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
