### PR TITLE
[Calendar] add teams meeting link and show the infos

### DIFF
--- a/skills/csharp/calendarskill/CalendarSkill.csproj
+++ b/skills/csharp/calendarskill/CalendarSkill.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Search" Version="10.0.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using CalendarSkill.Models;
 using CalendarSkill.Models.DialogOptions;
 using CalendarSkill.Options;
@@ -1096,8 +1097,9 @@ namespace CalendarSkill.Dialogs
                 attendeePhotoList,
                 subject = eventItem.Title,
                 location = eventItem.Location,
-                content = eventItem.ContentPreview ?? eventItem.Content,
-                meetingLink = eventItem.OnlineMeetingUrl
+                content = !string.IsNullOrEmpty(eventItem.OnlineMeetingUrl) ?
+                    GetOnlineMeetingInfo(eventItem.OnlineMeetingUrl, eventItem.OnlineMeetingTollNumber, eventItem.OnlineMeetingConferenceId) :
+                    eventItem.ContentPreview,
             };
 
             var cardName = GetDivergedCardName(dc.Context, SummaryResponses.MeetingDetailCard);
@@ -2400,6 +2402,22 @@ namespace CalendarSkill.Dialogs
             {
                 return card;
             }
+        }
+
+        private string GetOnlineMeetingInfo(string link, string tollNumber, string conferenceId)
+        {
+            string info = "## [Join Microsoft Teams Meeting](" + link + ")";
+            if (!string.IsNullOrEmpty(tollNumber))
+            {
+                info += "\r\n### [" + tollNumber + "](" + "tel:" + HttpUtility.UrlEncode(tollNumber) + ")";
+            }
+
+            if (!string.IsNullOrEmpty(conferenceId))
+            {
+                info += "\r\nConference ID: " + conferenceId + "#";
+            }
+
+            return info;
         }
 
         private List<EventModel> GetCurrentPageMeetings(CalendarSkillState state)

--- a/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
@@ -621,6 +621,7 @@ namespace CalendarSkill.Dialogs
                     EndTime = (DateTime)state.MeetingInfo.EndDateTime,
                     TimeZone = TimeZoneInfo.Utc,
                     Location = state.MeetingInfo.MeetingRoom == null ? state.MeetingInfo.Location : null,
+                    IsOnlineMeeting = true
                 };
 
                 var status = false;

--- a/skills/csharp/calendarskill/Models/EventModel.cs
+++ b/skills/csharp/calendarskill/Models/EventModel.cs
@@ -714,14 +714,87 @@ namespace CalendarSkill.Models
                 switch (source)
                 {
                     case EventSource.Microsoft:
-                        if (msftEventData.OnlineMeetingUrl == string.Empty)
+                        if (string.IsNullOrEmpty(msftEventData.OnlineMeeting?.JoinUrl))
                         {
                             return null;
                         }
 
-                        return msftEventData.OnlineMeetingUrl;
+                        return msftEventData.OnlineMeeting.JoinUrl;
                     case EventSource.Google:
                         return null;
+                    default:
+                        throw new Exception("Event Type not Defined");
+                }
+            }
+        }
+
+        public string OnlineMeetingTollNumber
+        {
+            get
+            {
+                switch (source)
+                {
+                    case EventSource.Microsoft:
+                        if (string.IsNullOrEmpty(msftEventData.OnlineMeeting?.TollNumber))
+                        {
+                            return null;
+                        }
+
+                        return msftEventData.OnlineMeeting.TollNumber;
+                    case EventSource.Google:
+                        return null;
+                    default:
+                        throw new Exception("Event Type not Defined");
+                }
+            }
+        }
+
+        public string OnlineMeetingConferenceId
+        {
+            get
+            {
+                switch (source)
+                {
+                    case EventSource.Microsoft:
+                        if (string.IsNullOrEmpty(msftEventData.OnlineMeeting?.ConferenceId))
+                        {
+                            return null;
+                        }
+
+                        return msftEventData.OnlineMeeting.ConferenceId;
+                    case EventSource.Google:
+                        return null;
+                    default:
+                        throw new Exception("Event Type not Defined");
+                }
+            }
+        }
+
+        public bool? IsOnlineMeeting
+        {
+            get
+            {
+                switch (source)
+                {
+                    case EventSource.Microsoft:
+                        return msftEventData.IsOnlineMeeting;
+                    case EventSource.Google:
+                        return null;
+                    default:
+                        throw new Exception("Event Type not Defined");
+                }
+            }
+
+            set
+            {
+                switch (source)
+                {
+                    case EventSource.Microsoft:
+                        msftEventData.IsOnlineMeeting = value;
+                        break;
+                    case EventSource.Google:
+                        // todo check google ones
+                        break;
                     default:
                         throw new Exception("Event Type not Defined");
                 }

--- a/skills/csharp/tests/calendarskill.tests/Flow/NextCalendarFlowTests.cs
+++ b/skills/csharp/tests/calendarskill.tests/Flow/NextCalendarFlowTests.cs
@@ -42,8 +42,7 @@ namespace CalendarSkill.Test.Flow
                 .Send(string.Empty)
                 .AssertReplyOneOf(GetTemplates(CalendarMainResponses.FirstPromptMessage))
                 .Send(FindMeetingTestUtterances.BaseNextMeeting)
-                .AssertReplyOneOf(this.NextMeetingPrompt())
-                .AssertReply(this.ShowCalendarList())
+                .AssertReply(this.ReadOneEvent())
                 .StartTestAsync();
         }
 
@@ -56,8 +55,7 @@ namespace CalendarSkill.Test.Flow
                 .Send(FindMeetingTestUtterances.HowLongNextMeetingMeeting)
                 .AssertReplyOneOf(this.BeforeShowEventDetailsPrompt())
                 .AssertReplyOneOf(this.ReadDurationPrompt())
-                .AssertReplyOneOf(this.NextMeetingPrompt())
-                .AssertReply(this.ShowCalendarList())
+                .AssertReply(this.ReadOneEvent())
                 .StartTestAsync();
         }
 
@@ -70,8 +68,7 @@ namespace CalendarSkill.Test.Flow
                 .Send(FindMeetingTestUtterances.WhereNextMeetingMeeting)
                 .AssertReplyOneOf(this.BeforeShowEventDetailsPrompt())
                 .AssertReplyOneOf(this.ReadLocationPrompt())
-                .AssertReplyOneOf(this.NextMeetingPrompt())
-                .AssertReply(this.ShowCalendarList())
+                .AssertReply(this.ReadOneEvent())
                 .StartTestAsync();
         }
 
@@ -84,8 +81,7 @@ namespace CalendarSkill.Test.Flow
                 .Send(FindMeetingTestUtterances.WhenNextMeetingMeeting)
                 .AssertReplyOneOf(this.BeforeShowEventDetailsPrompt())
                 .AssertReplyOneOf(this.ReadTimePrompt())
-                .AssertReplyOneOf(this.NextMeetingPrompt())
-                .AssertReply(this.ShowCalendarList())
+                .AssertReply(this.ReadOneEvent())
                 .StartTestAsync();
         }
 
@@ -167,11 +163,13 @@ namespace CalendarSkill.Test.Flow
             return GetTemplates(SummaryResponses.ShowNoMeetingMessage);
         }
 
-        private Action<IActivity> ActionEndMessage()
+        private Action<IActivity> ReadOneEvent(string suffix = "")
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                var messageActivity = activity.AsMessageActivity();
+                CollectionAssert.Contains(GetTemplates(SummaryResponses.ShowNextMeetingMessage), messageActivity.Text);
+                Assert.AreEqual(messageActivity.Attachments.Count, 1);
             };
         }
     }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
close #189 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
1. update MSGraph to 3.7
2. add online meeting link in CreateMeeting
3. provide the meeting link and phone number info in ShowMeeting
4. change "next meeting" behavior, show the detail card when there is just one event.

![image](https://user-images.githubusercontent.com/44257569/84774379-53326b80-b010-11ea-94e8-14e64f4d95f8.png)
![image](https://user-images.githubusercontent.com/44257569/84774447-6c3b1c80-b010-11ea-8bff-5cef7853f004.png)
![image](https://user-images.githubusercontent.com/44257569/84774538-8bd24500-b010-11ea-9792-4839bdb28fbd.png)


### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*


### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
