### PR TITLE
[Calendar] remove prebuilt personName from de/it/fr/es calendar.lu

### DIFF
--- a/skills/csharp/calendarskill/Deployment/Resources/LU/de-de/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/de-de/Calendar.lu
@@ -1877,8 +1877,6 @@ $FloorNumber:simple
 
 $PREBUILT:datetimeV2
 
-$PREBUILT:personName
-
 $PREBUILT:ordinal
 
 

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/es-es/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/es-es/Calendar.lu
@@ -1856,8 +1856,6 @@ $FloorNumber:simple
 
 $PREBUILT:datetimeV2
 
-$PREBUILT:personName
-
 $PREBUILT:ordinal
 
 

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/fr-fr/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/fr-fr/Calendar.lu
@@ -1864,8 +1864,6 @@ $FloorNumber:simple
 
 $PREBUILT:datetimeV2
 
-$PREBUILT:personName
-
 $PREBUILT:ordinal
 
 

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/it-it/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/it-it/Calendar.lu
@@ -1855,8 +1855,6 @@ $FloorNumber:simple
 
 $PREBUILT:datetimeV2
 
-$PREBUILT:personName
-
 $PREBUILT:ordinal
 
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
close #285 
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
