### PR TITLE
[Calendar] fix displaying wrong timezone in outlook

### DIFF
--- a/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
@@ -612,14 +612,15 @@ namespace CalendarSkill.Dialogs
                     });
                 }
 
+                var userTimezone = state.GetUserTimeZone();
                 var newEvent = new EventModel(source)
                 {
                     Title = state.MeetingInfo.Title,
                     Content = state.MeetingInfo.Content,
                     Attendees = state.MeetingInfo.ContactInfor.Contacts,
-                    StartTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.StartDateTime, state.GetUserTimeZone()),
-                    EndTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.EndDateTime, state.GetUserTimeZone()),
-                    TimeZone = state.GetUserTimeZone(),
+                    StartTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.StartDateTime, userTimezone),
+                    EndTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.EndDateTime, userTimezone),
+                    TimeZone = userTimezone,
                     Location = state.MeetingInfo.MeetingRoom == null ? state.MeetingInfo.Location : null,
                     IsOnlineMeeting = true
                 };

--- a/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
@@ -617,9 +617,9 @@ namespace CalendarSkill.Dialogs
                     Title = state.MeetingInfo.Title,
                     Content = state.MeetingInfo.Content,
                     Attendees = state.MeetingInfo.ContactInfor.Contacts,
-                    StartTime = (DateTime)state.MeetingInfo.StartDateTime,
-                    EndTime = (DateTime)state.MeetingInfo.EndDateTime,
-                    TimeZone = TimeZoneInfo.Utc,
+                    StartTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.StartDateTime, state.GetUserTimeZone()),
+                    EndTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.MeetingInfo.EndDateTime, state.GetUserTimeZone()),
+                    TimeZone = state.GetUserTimeZone(),
                     Location = state.MeetingInfo.MeetingRoom == null ? state.MeetingInfo.Location : null,
                     IsOnlineMeeting = true
                 };
@@ -627,7 +627,8 @@ namespace CalendarSkill.Dialogs
                 var status = false;
                 sc.Context.TurnState.TryGetValue(StateProperties.APITokenKey, out var token);
                 var calendarService = ServiceManager.InitCalendarService(token as string, state.EventSource);
-                if (await calendarService.CreateEventAsync(newEvent) != null)
+                var createdEvent = await calendarService.CreateEventAsync(newEvent);
+                if (createdEvent != null)
                 {
                     var activity = TemplateManager.GenerateActivityForLocale(CreateEventResponses.MeetingBooked);
                     await sc.Context.SendActivityAsync(activity, cancellationToken);

--- a/skills/csharp/calendarskill/Dialogs/UpdateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/UpdateEventDialog.cs
@@ -190,13 +190,13 @@ namespace CalendarSkill.Dialogs
                 var state = await Accessor.GetAsync(sc.Context, cancellationToken: cancellationToken);
                 var options = (CalendarSkillDialogOptions)sc.Options;
 
-                var newStartTime = (DateTime)state.UpdateMeetingInfo.NewStartDateTime;
+                var newStartTime = TimeConverter.ConvertUtcToUserTime((DateTime)state.UpdateMeetingInfo.NewStartDateTime, state.GetUserTimeZone());
                 var origin = state.ShowMeetingInfo.FocusedEvents[0];
                 var updateEvent = new EventModel(origin.Source);
                 var last = origin.EndTime - origin.StartTime;
+                updateEvent.TimeZone = state.GetUserTimeZone();
                 updateEvent.StartTime = newStartTime;
                 updateEvent.EndTime = (newStartTime + last).AddSeconds(1);
-                updateEvent.TimeZone = TimeZoneInfo.Utc;
                 updateEvent.Id = origin.Id;
 
                 if (!string.IsNullOrEmpty(state.UpdateMeetingInfo.RecurrencePattern) && !string.IsNullOrEmpty(origin.RecurringId))

--- a/skills/csharp/calendarskill/Models/EventModel.cs
+++ b/skills/csharp/calendarskill/Models/EventModel.cs
@@ -369,7 +369,7 @@ namespace CalendarSkill.Models
                             msftEventData.Start.DateTime = msftEventData.Start.DateTime + "Z";
                         }
 
-                        var start = DateTime.Parse(msftEventData.Start.DateTime);
+                        var start = new DateTime(DateTime.Parse(msftEventData.Start.DateTime).Ticks, DateTimeKind.Unspecified);
 
                         if (this.TimeZone.Id != "UTC")
                         {
@@ -433,7 +433,7 @@ namespace CalendarSkill.Models
                             msftEventData.End.DateTime = msftEventData.End.DateTime + "Z";
                         }
 
-                        var end = DateTime.Parse(msftEventData.End.DateTime);
+                        var end = new DateTime(DateTime.Parse(msftEventData.End.DateTime).Ticks, DateTimeKind.Unspecified);
 
                         if (this.TimeZone.Id != "UTC")
                         {

--- a/skills/csharp/calendarskill/Models/EventModel.cs
+++ b/skills/csharp/calendarskill/Models/EventModel.cs
@@ -371,7 +371,7 @@ namespace CalendarSkill.Models
 
                         var start = new DateTime(DateTime.Parse(msftEventData.Start.DateTime).Ticks, DateTimeKind.Unspecified);
 
-                        if (this.TimeZone.Id != "UTC")
+                        if (this.TimeZone.Id != CalendarCommonUtil.UTCTimeZone)
                         {
                             return TimeZoneInfo.ConvertTimeToUtc(start, this.TimeZone).ToUniversalTime();
                         }
@@ -435,7 +435,7 @@ namespace CalendarSkill.Models
 
                         var end = new DateTime(DateTime.Parse(msftEventData.End.DateTime).Ticks, DateTimeKind.Unspecified);
 
-                        if (this.TimeZone.Id != "UTC")
+                        if (this.TimeZone.Id != CalendarCommonUtil.UTCTimeZone)
                         {
                             TimeZoneInfo.ConvertTimeToUtc(end, this.TimeZone).ToUniversalTime();
                         }

--- a/skills/csharp/calendarskill/Models/EventModel.cs
+++ b/skills/csharp/calendarskill/Models/EventModel.cs
@@ -369,7 +369,14 @@ namespace CalendarSkill.Models
                             msftEventData.Start.DateTime = msftEventData.Start.DateTime + "Z";
                         }
 
-                        return DateTime.Parse(msftEventData.Start.DateTime).ToUniversalTime();
+                        var start = DateTime.Parse(msftEventData.Start.DateTime);
+
+                        if (this.TimeZone.Id != "UTC")
+                        {
+                            return TimeZoneInfo.ConvertTimeToUtc(start, this.TimeZone).ToUniversalTime();
+                        }
+
+                        return start.ToUniversalTime();
                     case EventSource.Google:
                         return gmailEventData.Start.DateTime.Value.ToUniversalTime();
                     default:
@@ -379,11 +386,6 @@ namespace CalendarSkill.Models
 
             set
             {
-                if (value.Kind != DateTimeKind.Utc)
-                {
-                    throw new Exception("Model Start Time is not Utc Time");
-                }
-
                 switch (source)
                 {
                     case EventSource.Microsoft:
@@ -392,7 +394,7 @@ namespace CalendarSkill.Models
                             msftEventData.Start = new Microsoft.Graph.DateTimeTimeZone();
                         }
 
-                        msftEventData.Start.DateTime = value.ToString("o");
+                        msftEventData.Start.DateTime = value.ToString("yyyy-MM-ddTHH:mm:ss");
                         break;
                     case EventSource.Google:
                         if (gmailEventData.Start == null)
@@ -400,7 +402,7 @@ namespace CalendarSkill.Models
                             gmailEventData.Start = new Google.Apis.Calendar.v3.Data.EventDateTime();
                         }
 
-                        gmailEventData.Start.DateTimeRaw = value.ToString("o");
+                        gmailEventData.Start.DateTimeRaw = value.ToString("yyyy-MM-ddTHH:mm:ss");
                         break;
                     default:
                         throw new Exception("Event Type not Defined");
@@ -431,7 +433,14 @@ namespace CalendarSkill.Models
                             msftEventData.End.DateTime = msftEventData.End.DateTime + "Z";
                         }
 
-                        return DateTime.Parse(msftEventData.End.DateTime).ToUniversalTime();
+                        var end = DateTime.Parse(msftEventData.End.DateTime);
+
+                        if (this.TimeZone.Id != "UTC")
+                        {
+                            TimeZoneInfo.ConvertTimeToUtc(end, this.TimeZone).ToUniversalTime();
+                        }
+
+                        return end.ToUniversalTime();
                     case EventSource.Google:
                         return gmailEventData.End.DateTime.Value.ToUniversalTime();
                     default:
@@ -441,11 +450,6 @@ namespace CalendarSkill.Models
 
             set
             {
-                if (value.Kind != DateTimeKind.Utc)
-                {
-                    throw new Exception("Model End Time is not Utc Time");
-                }
-
                 switch (source)
                 {
                     case EventSource.Microsoft:
@@ -454,7 +458,7 @@ namespace CalendarSkill.Models
                             msftEventData.End = new Microsoft.Graph.DateTimeTimeZone();
                         }
 
-                        msftEventData.End.DateTime = value.ToString("o");
+                        msftEventData.End.DateTime = value.ToString("yyyy-MM-ddTHH:mm:ss");
                         break;
                     case EventSource.Google:
                         if (gmailEventData.End == null)
@@ -462,7 +466,7 @@ namespace CalendarSkill.Models
                             gmailEventData.End = new Google.Apis.Calendar.v3.Data.EventDateTime();
                         }
 
-                        gmailEventData.End.DateTimeRaw = value.ToString("o");
+                        gmailEventData.End.DateTimeRaw = value.ToString("yyyy-MM-ddTHH:mm:ss");
                         break;
                     default:
                         throw new Exception("Event Type not Defined");

--- a/skills/csharp/calendarskill/Utilities/CalendarCommonUtil.cs
+++ b/skills/csharp/calendarskill/Utilities/CalendarCommonUtil.cs
@@ -19,6 +19,8 @@ namespace CalendarSkill.Utilities
 
         public const int AvailabilityViewInterval = 5;
 
+        public const string UTCTimeZone = "UTC";
+
         public static async Task<List<EventModel>> GetEventsByTimeAsync(List<DateTime> startDateList, List<DateTime> startTimeList, List<DateTime> endDateList, List<DateTime> endTimeList, TimeZoneInfo userTimeZone, ICalendarService calendarService)
         {
             // todo: check input datetime is utc


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
fix and close:
https://github.com/microsoft/botframework-skills/issues/295

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
as the design before, all api calls use utc timezone. removed the utc timezone check and set user timezone when create/update meeting. keep the design of when get time from api calls it always returns utc time.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
