### PR TITLE
[Calendar v2] support accept/decline in update flow

### DIFF
--- a/skills/declarative/calendarSkill/dialogs/CreateEventDialog/language-understanding/en-us/CreateEventDialog.en-us.lu
+++ b/skills/declarative/calendarSkill/dialogs/CreateEventDialog/language-understanding/en-us/CreateEventDialog.en-us.lu
@@ -4,11 +4,6 @@
 - skip that
 - nothing
 - none
-# ChangeDuration
-- I want to set up a meeting for 1 hr with Anna
-- Change the duration to 2,5 hrs
-- I want the meeting to last for 45 minutes
-- Change duration
 
 @ prebuilt datetimeV2
 
@@ -23,10 +18,6 @@
 # ChooseOwnDateTime
 - Choose own date and time
 - Choose my own date and time
-
-# ChangeTitle
-- change titile
-- update title
 
 # ChangeSlots
 - Can you {@EntityOperation={@Add=add}} Rachel

--- a/skills/declarative/calendarSkill/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
+++ b/skills/declarative/calendarSkill/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
@@ -56,16 +56,184 @@
           "condition": "dialog.searchResults.IsOrganizer != true",
           "actions": [
             {
-              "$kind": "Microsoft.SendActivity",
+              "$kind": "Microsoft.ConfirmInput",
               "$designer": {
-                "id": "riAa5o"
+                "id": "35TBWD"
               },
-              "activity": "${SendActivity_riAa5o()}"
+              "defaultLocale": "en-us",
+              "disabled": false,
+              "maxTurnCount": 3,
+              "alwaysPrompt": false,
+              "allowInterruptions": false,
+              "prompt": "${ConfirmInput_Prompt_35TBWD()}",
+              "unrecognizedPrompt": "",
+              "invalidPrompt": "",
+              "defaultValueResponse": "",
+              "choiceOptions": {
+                "includeNumbers": true
+              },
+              "property": "dialog.attendanceConfirm"
+            },
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "UAxJ8x"
+              },
+              "condition": "dialog.attendanceConfirm == true",
+              "elseActions": [],
+              "actions": [
+                {
+                  "$kind": "Microsoft.IfCondition",
+                  "$designer": {
+                    "id": "RTIBEa"
+                  },
+                  "condition": "dialog.searchResults.Response == 'accepted'",
+                  "actions": [
+                    {
+                      "$kind": "Microsoft.ConfirmInput",
+                      "$designer": {
+                        "id": "ukUbCl"
+                      },
+                      "defaultLocale": "en-us",
+                      "disabled": false,
+                      "maxTurnCount": 3,
+                      "alwaysPrompt": false,
+                      "allowInterruptions": false,
+                      "prompt": "${ConfirmInput_Prompt_ukUbCl()}",
+                      "unrecognizedPrompt": "",
+                      "invalidPrompt": "",
+                      "defaultValueResponse": "",
+                      "choiceOptions": {
+                        "includeNumbers": true,
+                        "inlineOrMore": ", or ",
+                        "inlineOr": " or "
+                      },
+                      "property": "dialog.declineConfirm"
+                    },
+                    {
+                      "$kind": "Microsoft.IfCondition",
+                      "$designer": {
+                        "id": "yTNhgY"
+                      },
+                      "condition": "dialog.declineConfirm == true",
+                      "actions": [
+                        {
+                          "$kind": "Microsoft.SetProperty",
+                          "$designer": {
+                            "id": "VUS8Bc"
+                          },
+                          "property": "dialog.attendanceChoice",
+                          "value": "Decline"
+                        }
+                      ]
+                    }
+                  ],
+                  "elseActions": [
+                    {
+                      "$kind": "Microsoft.ChoiceInput",
+                      "$designer": {
+                        "id": "zl35Yb"
+                      },
+                      "defaultLocale": "en-us",
+                      "disabled": false,
+                      "maxTurnCount": 3,
+                      "alwaysPrompt": false,
+                      "allowInterruptions": false,
+                      "prompt": "${ChoiceInput_Prompt_zl35Yb()}",
+                      "unrecognizedPrompt": "",
+                      "invalidPrompt": "",
+                      "defaultValueResponse": "",
+                      "choiceOptions": {
+                        "includeNumbers": true,
+                        "inlineOrMore": ", or "
+                      },
+                      "choices": "['Accept', 'Decline']",
+                      "property": "dialog.attendanceChoice"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "$kind": "Microsoft.SwitchCondition",
+              "$designer": {
+                "id": "J0WiRH"
+              },
+              "condition": "dialog.attendanceChoice",
+              "cases": [
+                {
+                  "value": "Accept",
+                  "actions": [
+                    {
+                      "$kind": "Microsoft.Graph.Calendar.AcceptEvent",
+                      "$designer": {
+                        "id": "dN52m5"
+                      },
+                      "resultProperty": "dialog.acceptResult",
+                      "token": "=user.token.token",
+                      "eventId": "=dialog.searchResults.Id"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "$designer": {
+                        "id": "0hCUh3"
+                      },
+                      "property": "dialog.searchResults.Response",
+                      "value": "= 'accepted'"
+                    },
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "$designer": {
+                        "id": "gGtguW"
+                      },
+                      "activity": "${SendActivity_gGtguW()}"
+                    }
+                  ]
+                },
+                {
+                  "value": "Decline",
+                  "actions": [
+                    {
+                      "$kind": "Microsoft.Graph.Calendar.DeclineEvent",
+                      "$designer": {
+                        "id": "VTZXlp"
+                      },
+                      "resultProperty": "dialog.declineResult",
+                      "token": "=user.token.token",
+                      "eventId": "=dialog.searchResults.Id"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "$designer": {
+                        "id": "c6cjsb"
+                      },
+                      "property": "dialog.searchResults.Response",
+                      "value": "= 'declined'"
+                    },
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "$designer": {
+                        "id": "KK42Jp"
+                      },
+                      "activity": "${SendActivity_KK42Jp()}"
+                    }
+                  ]
+                }
+              ],
+              "default": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "nh9WQS"
+                  },
+                  "activity": "${SendActivity_nh9WQS()}"
+                }
+              ]
             },
             {
               "$kind": "Microsoft.EndDialog",
               "$designer": {
-                "id": "b8BT1W"
+                "id": "BR9s7s"
               }
             }
           ]

--- a/skills/declarative/calendarSkill/dialogs/UpdateEventDialog/language-generation/en-us/UpdateEventDialog.en-us.lg
+++ b/skills/declarative/calendarSkill/dialogs/UpdateEventDialog/language-generation/en-us/UpdateEventDialog.en-us.lg
@@ -1,5 +1,6 @@
 [import](common.lg)
 [import](event.lg)
+[import](calendarskill.lg)
 
 # SendActivity_ehvCtJ()
 - I can't update this event.
@@ -12,12 +13,36 @@
 - Alright, I've updated the event for you.
 - The event has been updated. 
 - The event has been saved and updated. 
-# SendActivity_riAa5o()
-- I see you are not the owner of the meeting. Would you like to update your response? 
-- I cannot update the meeting since you are not the organizer. Do you want to update your attendance?
-- Because you aren't the organizer of this meeting, I cannot update this booking. Want to update your response instead?
-
 # ConfirmUpdate()
 - Sure, you can update the event:
 - Alright, here you go:
 - Ready to update:
+# ConfirmInput_Prompt_35TBWD()
+- I see you are not the owner of the meeting. Would you like to update your response? 
+- I cannot update the meeting since you are not the organizer. Do you want to update your attendance?
+- Because you aren't the organizer of this meeting, I cannot update this booking. Want to update your response instead?
+
+# ConfirmInput_Prompt_ukUbCl()
+- OK, do you want to decline the event?
+- Sure, want to decline this event?
+- Would you like to decline this event?
+# ChoiceInput_Prompt_zl35Yb()
+- Alright, do you want to accept or decline the event?
+- OK, let me know if you want to accept or decline?
+- Would you like to accept or decline this event?
+- How would you like to answer - accept or decline?
+# SendActivity_nh9WQS()
+- No problem, I will leave the event as-is.
+- Alright, the event will remain the same.
+- OK, I won't change the event.
+- You got it. The event will remain as-is.
+# SendActivity_KK42Jp()
+[Activity
+    Text = ${RespondEventResponseText("declined", dialog.searchResults)}
+    attachments = ${json(EventRespondDetailCard(dialog.searchResults))}
+]
+# SendActivity_gGtguW()
+[Activity
+    Text = ${RespondEventResponseText("accepted", dialog.searchResults)}
+    attachments = ${json(EventRespondDetailCard(dialog.searchResults))}
+]

--- a/skills/declarative/calendarSkill/dialogs/UpdateSlots/UpdateSlots.dialog
+++ b/skills/declarative/calendarSkill/dialogs/UpdateSlots/UpdateSlots.dialog
@@ -641,56 +641,6 @@
           "value": "=dialog.newSlotsResult"
         }
       ]
-    },
-    {
-      "$kind": "Microsoft.OnDialogEvent",
-      "$designer": {
-        "id": "YyIGgF",
-        "name": "UpdateEventDuration"
-      },
-      "event": "UpdateEventDuration",
-      "actions": [
-        {
-          "$kind": "Microsoft.DateTimeInput",
-          "$designer": {
-            "id": "SSWMA3"
-          },
-          "disabled": false,
-          "maxTurnCount": 3,
-          "alwaysPrompt": false,
-          "allowInterruptions": false,
-          "prompt": "${DateTimeInput_Prompt_SSWMA3()}",
-          "unrecognizedPrompt": "",
-          "invalidPrompt": "",
-          "defaultValueResponse": "",
-          "property": "dialog.newDuration",
-          "value": "= turn.activity.text",
-          "outputFormat": "= this.value[0].Value"
-        },
-        {
-          "$kind": "Microsoft.SetProperties",
-          "$designer": {
-            "id": "WcoD0K"
-          },
-          "assignments": [
-            {
-              "property": "dialog.newSlotsResult.updateType",
-              "value": "duration"
-            },
-            {
-              "property": "dialog.newSlotsResult.newValue",
-              "value": "=dialog.newDuration"
-            }
-          ]
-        },
-        {
-          "$kind": "Microsoft.EndDialog",
-          "$designer": {
-            "id": "jXjVqh"
-          },
-          "value": "=dialog.newSlotsResult"
-        }
-      ]
     }
   ],
   "generator": "UpdateSlots.lg",

--- a/skills/declarative/calendarSkill/dialogs/UpdateSlots/language-generation/en-us/UpdateSlots.en-us.lg
+++ b/skills/declarative/calendarSkill/dialogs/UpdateSlots/language-generation/en-us/UpdateSlots.en-us.lg
@@ -6,14 +6,19 @@
 - What do you want to change about the event?
 - Tell me what you'd like to update.
 # TextInput_Prompt_gtOavc()
-- What is the new title of meeting
+- ${AskForNewValue('title')}
+
+# AskForNewValue(entity)
+- OK, I'll update the ${entity}. What should it be instead?
+- I can do that. What should the ${entity} be instead?
+- OK, for ${entity} what can I update it to?
+- Sure. What should I change the ${entity} to?
+
 
 # DateTimeInput_Prompt_a700t3()
-- OK, how long would you like this meeting to be?
-- OK, what is your preferred meeting duration?
+- ${AskForNewValue('duration')}
 # TextInput_Prompt_NdRLDG()
-- What is the new location of meeting
-
+- ${AskForNewValue('location')}
 
 
 
@@ -23,4 +28,4 @@
 - OK, how long would you like this meeting to be?
 - OK, what is your preferred meeting duration?
 # DateTimeInput_Prompt_fKknY3()
-- What is the new time?
+- ${AskForNewValue('date time')}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
1. support accept/decline meeting when user attempt to update the meeting that user is not owner
2. update lg of UpdateSlotsDialog
3. remove some useless lu

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
